### PR TITLE
Fixes bug in displaying simplify button

### DIFF
--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -419,7 +419,7 @@ class WorkSpace(QWidget):
             opButtons = []
             if len(operations) > 0:
                 if len(operations) == 1:
-                    if operations[0] != 'solve':
+                    if operations[0] == 'solve':
                         opButtons = ['simplify']
                 else:
                     opButtons = ['simplify']


### PR DESCRIPTION
Whenever equation has two options ,i.e. solve and simplify, the 'back' button only displayes the 'solve' button when clicked.
for example:
![capture](https://user-images.githubusercontent.com/32027962/50491959-fbc6c700-0a3a-11e9-8b95-f6705884dc72.PNG)


the pull request fixes this. #88 