### PR TITLE
Added "Invalid Expression" prompt when "DivideByZero" error is encountered.

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,10 @@ def init():
         if cin == 'gui':
             initGUI()
         else:
-            commandExec(cin)
+            try:
+                commandExec(cin)
+            except ZeroDivisionError:
+                print("Cannot divide by Zero!")
         cin = input('>>> ')
 
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ def init():
             try:
                 commandExec(cin)
             except ZeroDivisionError:
-                print("Cannot divide by Zero!")
+                print("Invalid Expression")
         cin = input('>>> ')
 
 

--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -234,14 +234,17 @@ class WorkSpace(QWidget):
         if self.textedit.toPlainText() == "":
             self.enableQSolver = True
             self.enableInteraction = False
-        if self.enableQSolver and self.showQSolver:
-            self.qSol, self.enableInteraction = quickSimplify(self)
-            if self.qSol is None:
+        try:
+            if self.enableQSolver and self.showQSolver:
+                self.qSol, self.enableInteraction = quickSimplify(self)
+                if self.qSol is None:
+                    self.qSol = ""
+                renderQuickSol(self, self.showQSolver)
+            elif self.showQSolver is False:
                 self.qSol = ""
-            renderQuickSol(self, self.showQSolver)
-        elif self.showQSolver is False:
-            self.qSol = ""
-            renderQuickSol(self, self.showQSolver)
+                renderQuickSol(self, self.showQSolver)
+        except ZeroDivisionError:
+            self.enableInteraction = False
         if self.enableInteraction:
             self.interactionModeButton.setEnabled(True)
         else:


### PR DESCRIPTION
_Earlier Behavior_ : GUI and CLI exit abruptly when DivideByZero error is encountered.
_Current Behavior_: "Invalid Expression" prompt is displayed ( and Interaction Button is disabled in GUI) when DivideByZero error is encountered.
_Examples:_
![gi1-2](https://user-images.githubusercontent.com/32799055/51070939-acee7380-166f-11e9-81b5-130e8b20b3dc.png)
![cli](https://user-images.githubusercontent.com/32799055/51070940-b11a9100-166f-11e9-8836-2b14573ecffa.png)
This also fixes  #77.