### PR TITLE
catching all invalid input given to CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def init():
         else:
             try:
                 commandExec(cin)
-            except ZeroDivisionError:
+            except Exception:
                 print("Invalid Expression")
         cin = input('>>> ')
 


### PR DESCRIPTION
We would not like to catch only the Zerodivisionerror, but all the incorrect inputs given.