### PR TITLE
Inconsistent simplification (add/subtract)

### DIFF
--- a/tests/test_calculus.py
+++ b/tests/test_calculus.py
@@ -19,7 +19,10 @@ def test_differentiate():
     assert quickTest("xy + xy^2 + xyz", differentiate, 'y') == "x+2.0xy+xz"
     assert quickTest("xy + xy^2 + xyz", differentiate, 'z') == "+xy"  # FIXME: Remove unnecessary sign '+'
 
-
+    assert quickTest("xy + z", differentiate, 'z') == "1"
+    assert quickTest("z + xy", differentiate, 'z') == "1"
+    assert quickTest("z - xy", differentiate, 'z') == "1"
+    assert quickTest("xy - z", differentiate, 'z') == "-1"
 ########################
 # calculus.integration #
 ########################

--- a/visma/io/tokenize.py
+++ b/visma/io/tokenize.py
@@ -1568,33 +1568,32 @@ def tokenizer(eqnString):
 def changeToken(tokens, variables, scope_times=0):
 
     if len(variables) != 0:
-        if variables[0].scope is not None:
-            for changeVariable in variables:
-                for token in tokens:
-                    if isinstance(token, Constant):
-                        if token.scope == changeVariable.scope:
-                            if changeVariable.coefficient is not None:
-                                token.coefficient = changeVariable.coefficient
-                            token.power = changeVariable.power
-                            token.value = changeVariable.value
-                            break
-                    elif isinstance(token, Variable):
-                        if token.scope == changeVariable.scope:
+        for changeVariable in variables:
+            for token in tokens:
+                if isinstance(token, Constant):
+                    if token.scope == changeVariable.scope:
+                        if changeVariable.coefficient is not None:
                             token.coefficient = changeVariable.coefficient
-                            token.power = changeVariable.power
-                            token.value = changeVariable.value
-                            break
-                    elif isinstance(token, Binary):
+                        token.power = changeVariable.power
+                        token.value = changeVariable.value
+                        break
+                elif isinstance(token, Variable):
+                    if token.scope == changeVariable.scope:
+                        token.coefficient = changeVariable.coefficient
+                        token.power = changeVariable.power
+                        token.value = changeVariable.value
+                        break
+                elif isinstance(token, Binary):
+                    if token.scope == changeVariable.scope:
+                        token.value = changeVariable.value
+                elif isinstance(token, Expression):
+                    if scope_times + 1 == len(changeVariable.scope):
                         if token.scope == changeVariable.scope:
-                            token.value = changeVariable.value
-                    elif isinstance(token, Expression):
-                        if scope_times + 1 == len(changeVariable.scope):
-                            if token.scope == changeVariable.scope:
-                                break
-                        elif token.scope == changeVariable.scope[0:(scope_times + 1)]:
-                            token.tokens = changeToken(
-                                token.tokens, token.scope, scope_times + 1)
                             break
+                    elif token.scope == changeVariable.scope[0:(scope_times + 1)]:
+                        token.tokens = changeToken(
+                            token.tokens, token.scope, scope_times + 1)
+                        break
     return tokens
 
 


### PR DESCRIPTION
### Inconsistency-
Inconsistency is observed as below :-  

| Testcase        | Actual Output           | Expected Output  |
| ------------- |:-------------:| -----:|
| `quickTest("xy + z", differentiate, 'z')`     | 0 | 1 |
| `quickTest("z + xy", differentiate, 'z')`      | 1      |   1  |
| `quickTest("xy - z", differentiate, 'z')` | 0      |    -1 |  

I added the above testcases to the test_calculus.py file. 
The current iteration of the program **fails** the new tests.

Also note that this bug does not appear when performing a normal `0 + 1` or `1 + 0` simplification.
### Proposed Fix-

The bug originates from a issue when `variable[0].scope` is `None` in the "`changeToken`" function located in tokenize.py .   When its value is `None`, the token is returned without any change (Intended). 
   
However, After removing the check condition, all test cases including the above ones pass. As an added bonus, the warnings dissapeared as well.  

I do not exactly know why it works but if someone can explain what `scope` is in a clear way, I can try making some sense out of it.



