### PR TITLE
Added a 'Equality Check' in case LHS and RHS aren't equal during simplify

### DIFF
--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -22,9 +22,9 @@ def test_simplify():
     assert quickTest("x/y + x/x + x/x^2 + x^2/x + x/y^2 + x^2/y + x + 1", simplify) == "xy^(-1)+x^(-1.0)+xy^(-2.0)+x^(2.0)y^(-1)+2.0x+2.0"
 
     assert quickTest("1 + 2 = 3", simplifyEquation) == "=0"  # FIXME: Vanishing zero
-    assert quickTest("1 + 2 = 4", simplifyEquation) == "-1.0=0"  # FIXME: Exclude these cases, raise math error
+    assert quickTest("1 + 2 = 4", simplifyEquation) == "-1.0=0"
 
-    assert quickTest("3*2 + 4*2 = 3*4", simplifyEquation) == "2.0=0"  # FIXME: Exclude these cases, raise math error
+    assert quickTest("3*2 + 4*2 = 3*4", simplifyEquation) == "2.0=0"
     assert quickTest("3*x = 4*x + 2*y", simplifyEquation) == "-x-2.0y=0"
     assert quickTest("1 - 1 = 3*x + 4*x + 2*y", simplifyEquation) == "7.0x+2.0y=0"
 
@@ -35,7 +35,7 @@ def test_simplify():
     assert quickTest("x = -1 + 2", simplifyEquation) == "x+1.0-2.0=0"  # FIXME: Further simplification required (simplification in RHS)
     assert quickTest("x*y + x*x + x*x^2 = x^2*x + x*y^2 + x^2*y", simplifyEquation) == "xy+x^(2)-xy^(2.0)-x^(2.0)y=0"
 
-    assert quickTest("3/2 + 4/2 = 2/4", simplifyEquation) == "3.0=0"  # FIXME: Exclude these cases, raise math error
+    assert quickTest("3/2 + 4/2 = 2/4", simplifyEquation) == "3.0=0"
     assert quickTest("x/5 + x/4 = 2/y", simplifyEquation) == "0.45x-2.0y^(-1)=0"
     assert quickTest("x/y + x/x + x/x^2 + x^2/x = x/y^2 + x^2/y + x - 1", simplifyEquation) == "xy^(-1)+2.0+x^(-1.0)-xy^(-2.0)-x^(2.0)y^(-1)=0"
 

--- a/visma/gui/cli.py
+++ b/visma/gui/cli.py
@@ -80,6 +80,7 @@ def commandExec(command):
         lTokens, _, _, equationTokens, comments = differentiate(lTokens, varName)
     printOnCLI(equationTokens, operation, comments, solutionType)
 
+
 def printOnCLI(equationTokens, operation, comments, solutionType):
     equationString = []
     for x in equationTokens:
@@ -101,7 +102,7 @@ def printOnCLI(equationTokens, operation, comments, solutionType):
         finalSteps += equationString[i] + 2*"\n"
 
     # This takes care if LHS and RHS produced after simplification are equal or not.
-    # If not equal a Math Error is generated. 
+    # If not equal a Math Error is generated.
     if (solutionType == 'equation'):
         lastStep = ''
         lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()

--- a/visma/gui/cli.py
+++ b/visma/gui/cli.py
@@ -78,10 +78,9 @@ def commandExec(command):
     elif operation == 'differentiate':
         lhs, rhs = getLHSandRHS(tokens)
         lTokens, _, _, equationTokens, comments = differentiate(lTokens, varName)
-    printOnCLI(equationTokens, operation, comments)
+    printOnCLI(equationTokens, operation, comments, solutionType)
 
-
-def printOnCLI(equationTokens, operation, comments):
+def printOnCLI(equationTokens, operation, comments, solutionType):
     equationString = []
     for x in equationTokens:
         equationString.append(tokensToString(x))
@@ -100,4 +99,13 @@ def printOnCLI(equationTokens, operation, comments):
         else:
             finalSteps += "\n"
         finalSteps += equationString[i] + 2*"\n"
+
+    # This takes care if LHS and RHS produced after simplification are equal or not.
+    # If not equal a Math Error is generated. 
+    if (solutionType == 'equation'):
+        lastStep = ''
+        lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
+        if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and lastStep[0] != 'x' and lastStep[0] != 'y' and lastStep[0] != 'z'):
+            finalSteps += 'Math Error: LHS not equal to RHS' + "\n"
+
     print(finalSteps)

--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -30,6 +30,7 @@ from visma.solvers.solve import solveFor
 from visma.solvers.polynomial.roots import quadraticRoots
 from visma.transform.factorization import factorize
 from visma.gui import logger
+from visma.io.parser import tokensToString
 
 
 class Window(QtWidgets.QMainWindow):
@@ -122,7 +123,7 @@ class WorkSpace(QWidget):
     solutionButtons = {}
     inputBox = QGridLayout()
     selectedCombo = "Greek"
-    equations = []
+     equations = []
     stepsFontSize = 1
     axisRange = [10, 10, 10, 30]  # axisRange[-1] --> MeshDensity in 3D graphs
     resultOut = False
@@ -642,6 +643,13 @@ class WorkSpace(QWidget):
             if self.resultOut:
                 self.eqToks = equationTokens
                 self.output = resultLatex(name, equationTokens, comments)
+                # This takes care if LHS and RHS produced after simplification are equal or not.
+                # If not equal a Math Error is generated. 
+                if (self.solutionType == 'equation'):
+                    lastStep = ''
+                    lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
+                    if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and lastStep[0] != 'x' and lastStep[0] != 'y' and lastStep[0] != 'z'):
+                        self.output += 'Math Error: LHS not equal to RHS' + '\n'                
                 if len(availableOperations) == 0:
                     self.clearButtons()
                 else:

--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -123,7 +123,7 @@ class WorkSpace(QWidget):
     solutionButtons = {}
     inputBox = QGridLayout()
     selectedCombo = "Greek"
-     equations = []
+    equations = []
     stepsFontSize = 1
     axisRange = [10, 10, 10, 30]  # axisRange[-1] --> MeshDensity in 3D graphs
     resultOut = False
@@ -644,12 +644,12 @@ class WorkSpace(QWidget):
                 self.eqToks = equationTokens
                 self.output = resultLatex(name, equationTokens, comments)
                 # This takes care if LHS and RHS produced after simplification are equal or not.
-                # If not equal a Math Error is generated. 
+                # If not equal a Math Error is generated.
                 if (self.solutionType == 'equation'):
                     lastStep = ''
                     lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
                     if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and lastStep[0] != 'x' and lastStep[0] != 'y' and lastStep[0] != 'z'):
-                        self.output += 'Math Error: LHS not equal to RHS' + '\n'                
+                        self.output += 'Math Error: LHS not equal to RHS' + '\n'
                 if len(availableOperations) == 0:
                     self.clearButtons()
                 else:


### PR DESCRIPTION
_Earlier behaviour_ : When RHS and LHS aren't equal after doing a simplify it displayed equation without giving any Maths Error which is often misleading.
_Proposed behavior_ : In above mentioned cases it simplification results in unequal LHS and RHS it gives a Math Error, as evident in following cases:
+ for GUI: 
![guioutput](https://user-images.githubusercontent.com/32799055/53826327-61d14c80-3f9e-11e9-9725-bd1fc26f6ac0.png)
+ for CLI:
https://pastebin.com/TqdV2iaq
_It fixes one of FIXME's mentioned in Code_