### PR TITLE
Adds module for 'mathError' checking

### DIFF
--- a/visma/gui/cli.py
+++ b/visma/gui/cli.py
@@ -107,7 +107,7 @@ def printOnCLI(equationTokens, operation, comments, solutionType):
     if (solutionType == 'equation' and operation != 'solve'):
         lastStep = ''
         lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
-        if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and lastStep[0] != 'x' and lastStep[0] != 'y' and lastStep[0] != 'z'):
+        if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and 'x' not in lastStep[0] and 'y' not in lastStep[0] and 'z' not in lastStep[0]):
             finalSteps += 'Math Error: LHS not equal to RHS' + "\n"
 
     print(finalSteps)

--- a/visma/gui/cli.py
+++ b/visma/gui/cli.py
@@ -1,6 +1,6 @@
 from visma.calculus.differentiation import differentiate
 from visma.calculus.integration import integrate
-from visma.io.checks import checkTypes
+from visma.io.checks import checkTypes, mathError
 from visma.io.tokenize import tokenizer, getLHSandRHS
 from visma.io.parser import tokensToString
 from visma.simplify.simplify import simplify, simplifyEquation
@@ -102,12 +102,7 @@ def printOnCLI(equationTokens, operation, comments, solutionType):
             finalSteps += "\n"
         finalSteps += equationString[i] + 2*"\n"
 
-    # This takes care if LHS and RHS produced after simplification are equal or not.
-    # If not equal a Math Error is generated.
-    if (solutionType == 'equation' and operation != 'solve'):
-        lastStep = ''
-        lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
-        if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and 'x' not in lastStep[0] and 'y' not in lastStep[0] and 'z' not in lastStep[0]):
-            finalSteps += 'Math Error: LHS not equal to RHS' + "\n"
+    if (mathError(equationTokens[-1])):
+        finalSteps += 'Math Error: LHS not equal to RHS' + "\n"
 
     print(finalSteps)

--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -16,7 +16,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 from visma.calculus.differentiation import differentiate
 from visma.calculus.integration import integrate
-from visma.io.checks import checkTypes, getVariables
+from visma.io.checks import checkTypes, getVariables, mathError
 from visma.io.tokenize import tokenizer, getLHSandRHS
 from visma.io.parser import resultLatex
 from visma.gui.plotter import plotFigure2D, plotFigure3D, plot
@@ -30,7 +30,6 @@ from visma.solvers.solve import solveFor
 from visma.solvers.polynomial.roots import quadraticRoots
 from visma.transform.factorization import factorize
 from visma.gui import logger
-from visma.io.parser import tokensToString
 
 
 class Window(QtWidgets.QMainWindow):
@@ -643,13 +642,8 @@ class WorkSpace(QWidget):
             if self.resultOut:
                 self.eqToks = equationTokens
                 self.output = resultLatex(name, equationTokens, comments)
-                # This takes care if LHS and RHS produced after simplification are equal or not.
-                # If not equal a Math Error is generated.
-                if (self.solutionType == 'equation' and self.operation != 'solve'):
-                    lastStep = ''
-                    lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
-                    if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and 'x' not in lastStep[0] and 'y' not in lastStep[0] and 'z' not in lastStep[0]):
-                        self.output += 'Math Error: LHS not equal to RHS' + '\n'
+                if (mathError(self.eqToks[-1])):
+                    self.output += 'Math Error: LHS not equal to RHS' + "\n"
                 if len(availableOperations) == 0:
                     self.clearButtons()
                 else:

--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -648,7 +648,7 @@ class WorkSpace(QWidget):
                 if (self.solutionType == 'equation' and self.operation != 'solve'):
                     lastStep = ''
                     lastStep = tokensToString(equationTokens[len(equationTokens) - 1]).split()
-                    if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and lastStep[0] != 'x' and lastStep[0] != 'y' and lastStep[0] != 'z'):
+                    if (lastStep[0] != lastStep[len(lastStep) - 1] and len(lastStep) == 3 and 'x' not in lastStep[0] and 'y' not in lastStep[0] and 'z' not in lastStep[0]):
                         self.output += 'Math Error: LHS not equal to RHS' + '\n'
                 if len(availableOperations) == 0:
                     self.clearButtons()

--- a/visma/io/checks.py
+++ b/visma/io/checks.py
@@ -6,6 +6,7 @@ from visma.functions.constant import Constant
 from visma.functions.variable import Variable
 from visma.functions.operator import Operator, Binary
 
+
 greek = [u'\u03B1', u'\u03B2', u'\u03B3']
 
 funcs = ['log', 'log_', 'ln', 'exp', 'sin', 'cos', 'tan', 'csc', 'sec', 'cot', 'asin', 'acos', 'atan', 'sinh', 'cosh', 'tanh', 'asinh', 'acosh', 'atanh']
@@ -1110,3 +1111,25 @@ def getTokensType(tokens):
             elif token.value in ['<', '>', '<=', '>=']:
                 return "inequality"
     return "expression"
+
+
+def mathError(equationToken):
+    '''Checks if an equation token is mathematically correct or not
+    Typically, being used to check last equation token
+    (Checks if LHS and RHS of equation token are equal or not)
+
+    Arguments:
+        equationToken{list} -- Equation token
+
+    Returns:
+        True{bool} -- if there is some math error in the last step of equation
+        False{bool} -- if there is no math error in the last step of equation
+    '''
+    from visma.io.parser import tokensToString
+    equationTerms = tokensToString(equationToken).split()
+    print(equationTerms)
+    if len(equationToken) == 3:
+        if (isinstance(equationToken[0], Constant) and equationTerms[1] == '=' and isinstance(equationToken[2], Constant)):
+            if (equationToken[0].value != equationToken[2].value):
+                return True
+    return False

--- a/visma/io/checks.py
+++ b/visma/io/checks.py
@@ -1125,11 +1125,8 @@ def mathError(equationToken):
         True{bool} -- if there is some math error in the last step of equation
         False{bool} -- if there is no math error in the last step of equation
     '''
-    from visma.io.parser import tokensToString
-    equationTerms = tokensToString(equationToken).split()
-    print(equationTerms)
     if len(equationToken) == 3:
-        if (isinstance(equationToken[0], Constant) and equationTerms[1] == '=' and isinstance(equationToken[2], Constant)):
-            if (equationToken[0].value != equationToken[2].value):
+        if (isinstance(equationToken[0], Constant) and isinstance(equationToken[1], Binary) and isinstance(equationToken[2], Constant)):
+            if (equationToken[0].value != equationToken[2].value and equationToken[1].value == '='):
                 return True
     return False


### PR DESCRIPTION
Earlier implementation displayed `Math Error: LHS not equal to RHS` for equations of type `2x = 0`, `3x = 0`, `x + x + y = y` etc. This PR removes this bug.
```
>>> simplify(x +  x + y = y)
INPUT: x + x + y = y
OPERATION: simplify
OUTPUT: 2x = 0

x + x + y = y

(Adding x and x)
2x + y = y

(Moving [1]y^[1] to LHS)
2x = 0
```
PR for ref. #126 