### PR TITLE
Added module for PostProcessing after simplification

### DIFF
--- a/tests/test_calculus.py
+++ b/tests/test_calculus.py
@@ -12,8 +12,8 @@ def test_differentiate():
     assert quickTest("x^2 + x", differentiate, 'x') == "2.0x+1"
 
     assert quickTest("x + 2y + 3z + 4", differentiate, 'x') == "1"
-    # FIXME(tokensToString error): assert quickTest("x + 2y + 3z + 4", differentiate, 'y') == "2"
-    # FIXME(tokensToString error): assert quickTest("x + 2y + 3z + 4", differentiate, 'z') == "3"
+    assert quickTest("x + 2y + 3z + 4", differentiate, 'y') == "2.0"
+    assert quickTest("x + 2y + 3z + 4", differentiate, 'z') == "+3.0"
 
     assert quickTest("xy + xy^2 + xyz", differentiate, 'x') == "y+y^(2.0)+yz"
     assert quickTest("xy + xy^2 + xyz", differentiate, 'y') == "x+2.0xy+xz"

--- a/tests/test_calculus.py
+++ b/tests/test_calculus.py
@@ -13,11 +13,11 @@ def test_differentiate():
 
     assert quickTest("x + 2y + 3z + 4", differentiate, 'x') == "1"
     assert quickTest("x + 2y + 3z + 4", differentiate, 'y') == "2.0"
-    assert quickTest("x + 2y + 3z + 4", differentiate, 'z') == "+3.0"
+    assert quickTest("x + 2y + 3z + 4", differentiate, 'z') == "3.0"
 
     assert quickTest("xy + xy^2 + xyz", differentiate, 'x') == "y+y^(2.0)+yz"
     assert quickTest("xy + xy^2 + xyz", differentiate, 'y') == "x+2.0xy+xz"
-    assert quickTest("xy + xy^2 + xyz", differentiate, 'z') == "+xy"  # FIXME: Remove unnecessary sign '+'
+    assert quickTest("xy + xy^2 + xyz", differentiate, 'z') == "xy"
 
     assert quickTest("xy + z", differentiate, 'z') == "1"
     assert quickTest("z + xy", differentiate, 'z') == "1"

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -12,6 +12,8 @@ def test_simplify():
 
     assert quickTest("1 + 2 - 3", simplify) == "0"
     assert quickTest("1 + 2 - 4", simplify) == "-1.0"
+    assert quickTest("0 + 0 + 1", simplify) == "1.0"
+    assert quickTest("0 + 0 + xyz", simplify) == "xyz"
 
     assert quickTest("3*2 + 4*2 - 3*4", simplify) == "2.0"
     assert quickTest("3*x + 4*x - 2*y", simplify) == "7.0x-2.0y"

--- a/visma/io/checks.py
+++ b/visma/io/checks.py
@@ -1137,3 +1137,22 @@ def mathError(equationToken):
             if (equationToken[0].value != equationToken[2].value and equationToken[1].value == '='):
                 return True
     return False
+
+
+def postSimplification(tokens, animation):
+    '''Intended to apply certain transformations which may be needed to be applied after expression simplification
+    Typically being used to remove redundant '+' sign in expression beginning with it
+
+    Arguments:
+        tokens{list} -- tokens of CURRENT step
+        animation{list} -- list of tokens of ALL steps yet
+
+    Returns:
+        tokens{list} -- posprocessed tokens of CURRENT step
+        animation{list} -- list of postprocesses tokens of ALL steps
+    '''
+    if len(animation[-1]) == 2:
+        if isinstance(animation[-1][0], Binary) and animation[-1][0].value == '+':
+            animation[-1] = animation[-1][1:]
+            tokens = tokens[1:]
+    return tokens, animation

--- a/visma/matrix/structure.py
+++ b/visma/matrix/structure.py
@@ -174,7 +174,7 @@ class SquareMat(Matrix):
             ans, _, _, _, _ = simplify([a1[0], b, a2[0]])
         else:
             ans, _, _, _, _ = simplify(mat[0][0])
-        if(ans == []):
+        if not ans:
             ans = [Zero()]
         return ans
 

--- a/visma/simplify/addsub.py
+++ b/visma/simplify/addsub.py
@@ -1,6 +1,6 @@
 import copy
 from visma.io.parser import tokensToString
-from visma.io.checks import getLevelVariables, getOperationsEquation, getOperationsExpression
+from visma.io.checks import getLevelVariables, getOperationsEquation, getOperationsExpression, postSimplification
 from visma.functions.structure import Function, Expression
 from visma.functions.constant import Constant, Zero
 from visma.functions.variable import Variable
@@ -30,6 +30,7 @@ def addition(tokens, direct=False):
         comments.append(com)
         variables = getLevelVariables(tokens)
         availableOperations = getOperationsExpression(variables, tokens)
+    tokens, animation = postSimplification(tokens, animation)
     token_string = tokensToString(tokens)
     return tokens, availableOperations, token_string, animation, comments
 

--- a/visma/simplify/simplify.py
+++ b/visma/simplify/simplify.py
@@ -13,7 +13,7 @@ import copy
 from visma.functions.constant import Constant, Zero
 from visma.functions.variable import Variable
 from visma.functions.operator import Binary
-from visma.io.checks import isEquation, getLevelVariables, getOperationsEquation, getOperationsExpression
+from visma.io.checks import isEquation, getLevelVariables, getOperationsEquation, getOperationsExpression, postSimplification
 from visma.io.parser import tokensToString
 from visma.simplify.addsub import addition, additionEquation, subtraction, subtractionEquation
 from visma.simplify.muldiv import multiplication, multiplicationEquation, division, divisionEquation
@@ -212,6 +212,7 @@ def simplify(tokens):
             animation.pop(len(animation) - 1)
             animation.extend(anim)
             comments.extend(com)
+    tokens, animation = postSimplification(tokens, animation)
     token_string = tokensToString(tokens)
     return tokens, availableOperations, token_string, animation, comments
 


### PR DESCRIPTION
**_Bug_**: when given the command to simplify an expression like `0 + 0 + 1` it gave `+1` (an unnecessary + sign). Simplify module was not able to handle cases like these, which gave fixme's like `  assert quickTest("xy + xy^2 + xyz", differentiate, 'z') == "+xy"  # FIXME: Remove unnecessary sign '+'`

**_Solution_**: Added a postSimplification module in `io/checks.py` to handle this case. This module can be effectively used in future to apply any general post process (like error handling) to result produced after simplification.

Also fixed a small depreciation warning, fixed some `FIXME's` and added unit tests to illustrate the above behaviour. Thus increasing code coverage.