### PR TITLE
Simplification of expression

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,6 @@
 from visma.functions.constant import Constant
 from visma.functions.variable import Variable
+from tests.tester import getTokens
 
 
 ######################
@@ -39,3 +40,21 @@ def test_Variable():
     assert isinstance(variable2, Expression)
     assert variable2.__str__() == '{3log{x}}'
     '''
+
+
+#######################
+# functions.structure #
+#######################
+
+
+def test_reduce():
+
+    expr = getTokens("(2x+x)")
+    assert str(expr) == "3.0{x}"
+    assert expr.type == "Variable"
+
+    expr = getTokens("(3x+4*(x+(2x))+2y)")
+    assert str(expr) == "{(15.0{x}+2.0{y})}"
+
+    expr = getTokens("((2x+4x)+(2y+4y))")
+    assert str(expr) == "{(6.0{x}+6.0{y})}"

--- a/visma/functions/structure.py
+++ b/visma/functions/structure.py
@@ -178,6 +178,7 @@ class Expression(Function):
         self.tokens = []
         if tokens is not None:
             self.tokens.extend(tokens)
+            self.get_reduced()
         self.type = 'Expression'
 
     def __str__(self):
@@ -193,6 +194,14 @@ class Expression(Function):
         if self.operand is not None:
             represent += "{(" + str(self.operand) + ")}"
         return represent
+
+    def get_reduced(self):
+        '''Simpilifies the expression 
+        '''
+        from visma.simplify.simplify import simplify
+        self.tokens, _, _, _, _ = simplify(self.tokens)
+        if(self.__class__ == Expression):
+            self.reduced = True
 
 
 class Equation(Expression):

--- a/visma/functions/structure.py
+++ b/visma/functions/structure.py
@@ -196,7 +196,7 @@ class Expression(Function):
         return represent
 
     def get_reduced(self):
-        '''Simpilifies the expression 
+        '''Simpilifies the expression
         '''
         from visma.simplify.simplify import simplify
         self.tokens, _, _, _, _ = simplify(self.tokens)


### PR DESCRIPTION
This partially solves issue #141 

- Added property reduced in the Expression class.
- Added a class method, get_reduced() to simplify the expression.
-  If the expression is simplified to a single token, the class type changes from Expression to appropriate Function class. 