### PR TITLE
Cases involving expressions with powers and bug fixes

### DIFF
--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -46,12 +46,21 @@ def test_simplify():
     assert quickTest("x/5 + x/4 = 2/y", simplifyEquation) == "0.45x-2.0y^(-1)=0"
     assert quickTest("x/y + x/x + x/x^2 + x^2/x = x/y^2 + x^2/y + x - 1", simplifyEquation) == "xy^(-1)+2.0+x^(-1.0)-xy^(-2.0)-x^(2.0)y^(-1)=0"
 
+    # Tests regarding Expression Simplifications
     assert quickTest("(x + 1) * (x + 1) * (x + 1)", simplify) == "x^(3.0)+3x^(2.0)+3x+1.0"
     assert quickTest("(x + 1) * (x - 1) + (x + 2)", simplify) == "x^(2.0)+1.0+x"
     assert quickTest("(x + 1) + (x - 1)", simplify) == "2x"
     assert quickTest("(x + 1) * (x * (1 + x))", simplify) == "2x^(2.0)+x^(3.0)+x"
     assert quickTest("(x + 1) * (x - 1) + (100 + 1)", simplify) == "x^(2.0)+100.0"
     assert quickTest("((x + 1) * (x - 1) + (100 + 1))", simplify) == "x^(2.0)+100.0"
+
+    # Tests regarding Exponents & Expressions
+    assert quickTest("(x + 1)^3", simplify) == "x^(3.0)+3x^(2.0)+3x+1.0"
+    assert quickTest("(x + 1)^2*x", simplify) == "x^(3.0)+2x^(2.0)+x"
+    assert quickTest("x*(x + 1)^2*x", simplify) == "x^(4.0)+2x^(3.0)+x^(2.0)"
+    assert quickTest("(x+1)^2*(x + 2)^3*x", simplify) == "x^(6.0)+8.0x^(5.0)+25.0x^(4.0)+38.0x^(3.0)+28.0x^(2.0)+8.0x"
+    assert quickTest("(x + 1)^(1 + 1)*x", simplify) == "x^(3.0)+2x^(2.0)+x"
+    assert quickTest("(x + 1)^(3 + 0 + 0)", simplify) == "x^(3.0)+3x^(2.0)+3x+1.0"
 
 
 def test_addsub():

--- a/visma/io/checks.py
+++ b/visma/io/checks.py
@@ -872,7 +872,8 @@ def evaluateExpressions(variables):
                     if variables[i - 1].value in ['-', '+']:
                         prev = True
                 else:
-                    print(variables[i - 1])
+                    pass
+                    # print(variables[i - 1])
             else:
                 prev = True
 
@@ -881,7 +882,8 @@ def evaluateExpressions(variables):
                     if variables[i + 1].value in ['-', '+']:
                         nxt = True
                 else:
-                    print(variables[i + 1])
+                    pass
+                    # print(variables[i + 1])
             else:
                 nxt = True
             if nxt and prev:
@@ -905,7 +907,8 @@ def evaluateExpressions(variables):
                     if variables[i - 1].value in ['-', '+']:
                         prev = True
                 else:
-                    print(variables[i - 1])
+                    pass
+                    # print(variables[i - 1])
             else:
                 prev = True
 
@@ -914,7 +917,8 @@ def evaluateExpressions(variables):
                     if variables[i + 1].value in ['-', '+']:
                         nxt = True
                 else:
-                    print(variables[i + 1])
+                    pass
+                    # print(variables[i + 1])
             else:
                 nxt = True
             if nxt and prev:

--- a/visma/io/tokenize.py
+++ b/visma/io/tokenize.py
@@ -188,7 +188,12 @@ def tokenizeSymbols(terms):
     for i, term in enumerate(terms):
         symTokens.append('')
         if term in symbols:
-            if term == '*' or term == '/':
+            if term == '^':
+                if i + 1 < len(terms) and not isVariable(terms[i - 1]):
+                    symTokens[-1] = 'Binary'
+                else:
+                    symTokens[-1] = False
+            elif term == '*' or term == '/':
                 if i + 1 < len(terms):
                     if (isVariable(terms[i - 1]) or isNumber(terms[i - 1]) or terms[i - 1] == ')' or terms[i - 1] == ']') and (isVariable(terms[i + 1]) or isNumber(terms[i + 1]) or terms[i + 1] == '(' or terms[i + 1] == '[' or ((terms[i + 1] == '-' or terms[i + 1] == '+') and (isVariable(terms[i + 2]) or isNumber(terms[i + 2])))):
                         symTokens[-1] = 'Binary'
@@ -1476,9 +1481,10 @@ def getLHSandRHS(tokens):
 
 
 if __name__ == "__main__":
+    pass
     # logger.setLevel = 0
     # logger.setLogName = 'tokenize'
-    print(getLHSandRHS(tokenizer('0.2x^(2.0)+ 7.0x - 34.0')))
+    # print(getLHSandRHS(tokenizer('0.2x^(2.0)+ 7.0x - 34.0')))
 
 # -xy^22^22^-z^{s+y}^22=sqrt[x+1]{x}
 # x+y=2^-{x+y}

--- a/visma/simplify/simplify.py
+++ b/visma/simplify/simplify.py
@@ -193,9 +193,30 @@ def expressionSimplification(tokens_now, scope, tokens1):
     '''
     animation = []
     comments = []
-    simToks = []
+    pfTokens = []
+    i = 0
+    while(i < len(tokens1)):
+        if (i + 1 < len(tokens1)):
+            if isinstance(tokens1[i + 1], Expression) and isinstance(tokens1[i], Binary) and tokens1[i].value == '^':
+                tokens1[i + 1].tokens, _, _, _, _ = expressionSimplification(tokens_now, scope, tokens1[i + 1].tokens)
+                if len(tokens1[i + 1].tokens) == 1 and isinstance(tokens1[i + 1].tokens[0], Constant):
+                    tokens1[i + 1] = Constant(tokens1[i + 1].tokens[0].calculate(), 1, 1)
+            if (isinstance(tokens1[i], Binary) and tokens1[i].value == '^') and isinstance(tokens1[i + 1], Constant):
+                rep = int(tokens1[i + 1].calculate())
+                for _ in range(rep - 1):
+                    pfTokens.extend([Binary('*'), tokens1[i - 1]])
+                i += 1
+            else:
+                pfTokens.append(tokens1[i])
+        else:
+            pfTokens.append(tokens1[i])
+        i += 1
+    tokens1 = copy.deepcopy(pfTokens)
+    animation.append(pfTokens)
+    comments.append(['Expanding the powers of expressions'])
     mulFlag = True
     expressionMultiplication = False
+    # Check for the case: {Non-Expression} * {Expression}
     for _ in range(50):
         for i, _ in enumerate(tokens1):
             mulFlag = False
@@ -219,12 +240,37 @@ def expressionSimplification(tokens_now, scope, tokens1):
                         del tokens1[i - 1]
                         del tokens1[i - 2]
                         break
+    # Check for the case: {Expression} * {Non-Expression}
+    for _ in range(50):
+        for i, _ in enumerate(tokens1):
+            mulFlag = False
+            if isinstance(tokens1[i], Expression):
+                if (i + 2 < len(tokens1)):
+                    if (tokens1[i + 1].value == '*'):
+                        scope.append(i)
+                        tokens1[i].tokens, _, _, _, _ = expressionSimplification(tokens_now, scope, tokens1[i].tokens)
+                        if isinstance(tokens1[i + 2], Expression):
+                            scope.append(i + 2)
+                            tokens1[i + 2].tokens, _, _, _, _ = expressionSimplification(tokens_now, scope, tokens1[i + 2].tokens)
+                        a = tokens1[i + 2]
+                        b = tokens1[i]
+                        c = a * b
+                        mulFlag = True
+                        expressionMultiplication = True
+                        if isinstance(c, Expression):
+                            scope.append(i)
+                            c.tokens, _, _, _, _ = expressionSimplification(tokens_now, scope, c.tokens)
+                        tokens1[i] = c
+                        del tokens1[i + 1]
+                        del tokens1[i + 1]
+                        break
         if not mulFlag:
             break
     if expressionMultiplication:
         animation.append(tokens1)
         comments.append(['Multiplying expressions'])
     # TODO: Implement verbose multiplication steps.
+    simToks = []
     expressionPresent = False
     for i, _ in enumerate(tokens1):
         if isinstance(tokens1[i], Expression):


### PR DESCRIPTION
**Changelog:**
- Cases, when expressions are raised to some power (exponent), are now covered.
- Expressions like `(x+1)^2` were tokenized as `Expression`, this has now been taken care of and these are tokenized as `Expression + Binary('^') + Constant`.

**Issue Addressed:**
- #201 