### PR TITLE
when button create set enable false

### DIFF
--- a/visma/gui/window.py
+++ b/visma/gui/window.py
@@ -344,6 +344,7 @@ class WorkSpace(QWidget):
         interactionModeLayout = QVBoxLayout()
         self.interactionModeButton = QtWidgets.QPushButton('visma')
         self.interactionModeButton.clicked.connect(self.interactionMode)
+        self.interactionModeButton.setEnabled(False)
         interactionModeLayout.addWidget(self.interactionModeButton)
         interactionModeWidget = QWidget(self)
         interactionModeWidget.setLayout(interactionModeLayout)


### PR DESCRIPTION
Fixes #243 

When GUI start the visma button was with enable True by default, but when have no input the default should be eneable False.